### PR TITLE
Various CI fixes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,24 +36,29 @@ release:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/consul:$CURRENT_CI_IMAGE
   stage: release
   only:
-    - tags # needs to be the format v1.3.1-XXXX (-dd-2 for instance)
+    - tags # needs to be the format v1.3.1-XXXX (-dd2 for instance (for a "v1.3.1-dd2" tag))
   script:
-    - rm -rf /go/src/github.com/hashicorp/consul
-    - cp -a /go/src/github.com/DataDog/consul /go/src/github.com/hashicorp/consul
-    - cd /go/src/github.com/hashicorp/consul
-    - export PRERELEASE=$(echo $CI_COMMIT_TAG | cut -d '-' -f2-)
-    - sed -i "s/VersionPrerelease = \".*\"/VersionPrerelease = \"$PRERELEASE\"/" version/version.go
-    - make version
-    - make linux
-    - cd /go/src/github.com/hashicorp/consul/pkg/bin/linux_amd64
-    - zip consul_${CI_COMMIT_TAG}_linux_amd64.zip consul
-    - aws s3 cp ./consul_${CI_COMMIT_TAG}_linux_amd64.zip s3://devops-public/consul/
-    - cd /go/src/github.com/hashicorp/consul/fpm-recipe
-    - fpm-cook
-    - aws s3 cp ./pkg/consul_${CI_COMMIT_TAG}-1_amd64.deb s3://devops-public/consul/
-    - aws s3 sync s3://chow.datadoghq.com-test/ chow_repo
-    - aptly -config=aptly.conf repo create --distribution="bionic" bionic
-    - aptly -config=aptly.conf repo -remove-files=false -force-replace=true add bionic chow_repo
-    - aptly -config=aptly.conf repo -remove-files=false -force-replace=true add bionic ./pkg/consul_${CI_COMMIT_TAG}-1_amd64.deb
-    - "aptly -config=aptly.conf publish repo bionic s3:prod:"
-    - "aptly -config=aptly.conf publish update bionic s3:prod:"
+    - |-
+      set -x
+      rm -rf /go/src/github.com/hashicorp/consul
+      cp -a /go/src/github.com/DataDog/consul /go/src/github.com/hashicorp/consul
+      cd /go/src/github.com/hashicorp/consul
+      export PRERELEASE=${CI_COMMIT_TAG#*-}
+      export PACKAGE_VERSION=${CI_COMMIT_TAG##*v}
+      sed -i "s/VersionPrerelease = \".*\"/VersionPrerelease = \"$PRERELEASE\"/" version/version.go
+      make version
+      make linux
+      cd /go/src/github.com/hashicorp/consul/pkg/bin/linux_amd64
+      zip consul_${PACKAGE_VERSION}_linux_amd64.zip consul
+      aws s3 cp ./consul_${PACKAGE_VERSION}_linux_amd64.zip s3://devops-public/consul/
+      cd /go/src/github.com/hashicorp/consul/fpm-recipe
+      fpm-cook
+      aws s3 cp ./pkg/consul_${PACKAGE_VERSION}-1_amd64.deb s3://devops-public/consul/
+      for distro in trusty xenial bionic; do
+        aws s3 sync s3://chow.datadoghq.com/ chow_repo
+        aptly -config=aptly.conf repo create --distribution="${distro}" ${distro}
+        aptly -config=aptly.conf repo -remove-files=false -force-replace=true add ${distro} chow_repo
+        aptly -config=aptly.conf repo -remove-files=false -force-replace=true add ${distro} ./pkg/consul_${PACKAGE_VERSION}-1_amd64.deb
+        aptly -config=aptly.conf publish repo ${distro} "s3:prod:"
+        aptly -config=aptly.conf publish update ${distro} "s3:prod:"
+      done

--- a/fpm-recipe/recipe.rb
+++ b/fpm-recipe/recipe.rb
@@ -1,7 +1,7 @@
 class Consul < FPM::Cookery::Recipe
   name 'consul'
 
-  version ENV['CI_COMMIT_TAG']
+  version ENV['PACKAGE_VERSION']? ENV['PACKAGE_VERSION'] : ENV['CI_COMMIT_TAG'][/[0-9\-\._].*/]
   revision '1'
   description 'Consul Service Discovery Platform'
 


### PR DESCRIPTION
* Don't pull chow.datadoghq.com-test to later publish to prod, as test env may contain random garbage (eg. "+" replaced by " "), or may not be in sync with prod's content.
* Strip tag's "v" prefix (if any) from package name
* Also publish trusty and xenial